### PR TITLE
[FE][CPF-42] Button component and tailwind-prettier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # CPF
+
 ## Career Progression Framework Application
+
 Kellton Europe CPF app is an innovative web-based platform – a seamless solution designed to connect employees, managers, and directors to facilitate the career development of each team member. This dynamic application empowers employees to track progress and milestones toward their chosen career paths. Managers and directors can easily oversee employee development, monitor assigned goals, and provide essential support for continuous growth. Experience enhanced collaboration and foster a thriving, goal-oriented work environment with a cutting-edge platform.
 
 # Table of Contents
+
 - Installation
 - Usage
 - Wiki
@@ -10,32 +13,38 @@ Kellton Europe CPF app is an innovative web-based platform – a seamless soluti
 - License
 - Contact
 
-
 # Installation
+
 Instructions on how to install and set up the project.
 
 1. Copy variables to `.env` files.
-    ```
-    cp .envexample .env
-    ```
-2. Build and run the project
-    ```
+   ```
+   cp .envexample .env
+   ```
+
+- for testing purposes you might want to change flag `USE_MOCK_USER` to `True`
+
+1. Build and run the project
+   ```
    docker compose build
    docker compose up
    ```
    or just
-    ```
-    docker compose up --build
-    ```
-3. Open http://0.0.0.0:8080/ with your browser to see the result.
+   ```
+   docker compose up --build
+   ```
+2. Open http://0.0.0.0:8080/ with your browser to see the result.
 
 # Usage
+
 Instructions on how to use the project.
 
 # Wiki
+
 For more information, check out the project's wiki under the link: https://github.com/Tivix/cpf/wiki
 
 # Contributing
+
 Guidelines for contributing to the project.
 
 - Fork the repository.
@@ -46,9 +55,11 @@ Guidelines for contributing to the project.
 - Open a pull request.
 
 # License
+
 Specify the license under which the project is distributed.
 
 # Contact
+
 Contact information for the project maintainer or team.
 
 - Email: marcin.skorek@kellton.com, mateusz.jasinski@kellton.com

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -2,5 +2,6 @@
   "semi": true,
   "tabWidth": 2,
   "printWidth": 120,
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "husky": "^9.0.11",
     "postcss": "^8",
     "prettier": "3.2.5",
+    "prettier-plugin-tailwindcss": "^0.6.5",
     "tailwindcss": "^3.4.4",
     "typescript": "^5"
   },

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} bg-navy-50 h-full`}>
+      <body className={`${inter.className} h-full bg-navy-50`}>
         <div className="flex">
           <Sidebar />
           <div className="w-full">

--- a/frontend/src/app/(app)/library/page.tsx
+++ b/frontend/src/app/(app)/library/page.tsx
@@ -18,8 +18,8 @@ export default async function LibraryPage() {
 
   return (
     <div>
-      <h1 className="text-lg font-semibold text-navy-900 leading-6 mb-10">CPF Library</h1>
-      <p className="text-navy-600 tracking-wide mb-6">Select a career path to view the details.</p>
+      <h1 className="text-lg mb-10 font-semibold leading-6 text-navy-900">CPF Library</h1>
+      <p className="mb-6 tracking-wide text-navy-600">Select a career path to view the details.</p>
       <div className="grid grid-cols-3 gap-6">
         {data.map((ladder: LadderCardInterface) => (
           <LadderCard key={ladder.ladderSlug} {...ladder} />

--- a/frontend/src/app/(app)/page.tsx
+++ b/frontend/src/app/(app)/page.tsx
@@ -1,5 +1,5 @@
 export default function Home() {
   return (
-    <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">We shall see</div>
+    <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">We shall see</div>
   );
 }

--- a/frontend/src/components/common/AccordionCard/AccordionCard.tsx
+++ b/frontend/src/components/common/AccordionCard/AccordionCard.tsx
@@ -23,7 +23,7 @@ export const AccordionCard = ({
         <button
           type="button"
           className={generateClassNames(
-            'flex items-center justify-between w-full p-6 border border-navy-200 rounded-2xl',
+            'flex w-full items-center justify-between rounded-2xl border border-navy-200 p-6',
             {
               'hover:bg-navy-100': !isOpen && children,
               'hover:bg-transparent rounded-b-none border-b-0 pb-0': isOpen,
@@ -32,16 +32,16 @@ export const AccordionCard = ({
           )}
           onClick={() => setOpen(!isOpen)}
         >
-          <span className="text-navy-900 text-xl font-semibold">{title}</span>
+          <span className="text-xl font-semibold text-navy-900">{title}</span>
           {children ? (
-            <div className="rounded-full bg-navy-50 w-8 h-8 flex justify-center items-center">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-navy-50">
               <ChevronRightIcon className={generateClassNames('rotate-90 text-navy-500', { '-rotate-90': isOpen })} />
             </div>
           ) : undefined}
         </button>
       </h2>
       {children ? (
-        <div className={generateClassNames('border border-navy-200 border-t-0 rounded-b-2xl p-6', { hidden: !isOpen })}>
+        <div className={generateClassNames('rounded-b-2xl border border-t-0 border-navy-200 p-6', { hidden: !isOpen })}>
           {children}
         </div>
       ) : undefined}

--- a/frontend/src/components/common/AccordionList/AccordionListItem.tsx
+++ b/frontend/src/components/common/AccordionList/AccordionListItem.tsx
@@ -7,15 +7,15 @@ export const AccordionListItem = ({ title, children }: PropsWithChildren<Accordi
   const [isOpen, setOpen] = useState(false);
 
   return (
-    <div className="border-b border-b-navy-200 py-4 px-2">
+    <div className="border-b border-b-navy-200 px-2 py-4">
       <h3>
         <button
           type="button"
-          className={generateClassNames('flex items-center justify-between w-full', { 'cursor-auto': !children })}
+          className={generateClassNames('flex w-full items-center justify-between', { 'cursor-auto': !children })}
           onClick={() => setOpen(!isOpen)}
         >
-          <span className="text-navy-600 text-base font-medium text-left">{title}</span>
-          <div className="min-w-10 min-h-10 flex justify-center items-center">
+          <span className="text-left text-base font-medium text-navy-600">{title}</span>
+          <div className="flex min-h-10 min-w-10 items-center justify-center">
             {children ? (
               <ChevronRightIcon className={generateClassNames('rotate-90 text-navy-500', { '-rotate-90': isOpen })} />
             ) : undefined}
@@ -23,7 +23,7 @@ export const AccordionListItem = ({ title, children }: PropsWithChildren<Accordi
         </button>
       </h3>
       {children ? (
-        <div className={generateClassNames('mt-4 text-sm text-navy-600 font-normal', { hidden: !isOpen })}>
+        <div className={generateClassNames('mt-4 text-sm font-normal text-navy-600', { hidden: !isOpen })}>
           {children}
         </div>
       ) : undefined}

--- a/frontend/src/components/common/BucketCard/BucketCard.tsx
+++ b/frontend/src/components/common/BucketCard/BucketCard.tsx
@@ -8,15 +8,15 @@ export const BucketCard = ({ bucket }: BucketCardProps) => {
   return (
     <Link
       href={`/library/backend/${bucketSlug}`}
-      className="border border-navy-200 bg-white rounded-2xl flex cursor-pointer hover:bg-navy-100 flex-col p-6 gap-2"
+      className="flex cursor-pointer flex-col gap-2 rounded-2xl border border-navy-200 bg-white p-6 hover:bg-navy-100"
     >
       <div className="flex justify-between">
-        <h2 className="text-navy-900 text-xl font-semibold">{bucketName}</h2>
-        <div className="rounded-full bg-navy-50 w-8 h-8 flex justify-center items-center">
+        <h2 className="text-xl font-semibold text-navy-900">{bucketName}</h2>
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-navy-50">
           <ChevronRightIcon className="text-navy-500" />
         </div>
       </div>
-      <p className="text-navy-600 text-base">{description}</p>
+      <p className="text-base text-navy-600">{description}</p>
     </Link>
   );
 };

--- a/frontend/src/components/common/Button/Button.interface.ts
+++ b/frontend/src/components/common/Button/Button.interface.ts
@@ -1,0 +1,13 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+
+export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  styleType?: StyleTypes;
+  variant?: Variants;
+  disabled?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export type StyleTypes = 'primary' | 'natural' | 'warning';
+
+export type Variants = 'solid' | 'border' | 'borderless' | 'link';

--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -1,17 +1,6 @@
 import { generateClassNames } from '@app/utils';
-import React, { ButtonHTMLAttributes, ReactNode } from 'react';
-
-export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
-  styleType?: StyleTypes;
-  variant?: Variants;
-  disabled?: boolean;
-  className?: string;
-  children: ReactNode;
-}
-
-export type StyleTypes = 'primary' | 'natural' | 'warning';
-
-export type Variants = 'solid' | 'border' | 'borderless' | 'link';
+import React from 'react';
+import { Props, StyleTypes, Variants } from './Button.interface';
 
 const types: {
   [key in StyleTypes]: {
@@ -40,7 +29,7 @@ const types: {
   },
 };
 
-const Button = ({
+export const Button = ({
   styleType = 'primary',
   variant = 'solid',
   disabled = false,
@@ -63,5 +52,3 @@ const Button = ({
     </button>
   );
 };
-
-export default Button;

--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -1,0 +1,67 @@
+import { generateClassNames } from '@app/utils';
+import React, { ButtonHTMLAttributes, ReactNode } from 'react';
+
+export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  styleType?: StyleTypes;
+  variant?: Variants;
+  disabled?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export type StyleTypes = 'primary' | 'natural' | 'warning';
+
+export type Variants = 'solid' | 'border' | 'borderless' | 'link';
+
+const types: {
+  [key in StyleTypes]: {
+    [key in Variants]: string;
+  };
+} = {
+  primary: {
+    solid: 'bg-blue-600 text-white hover:bg-blue-900',
+    border:
+      'bg-white text-blue-800 border border-blue-800 hover:bg-navy-100 active:bg-white active:text-blue-900 active:border-blue-900',
+    borderless: 'px-2 bg-transparent text-blue-800 hover:bg-navy-100 active:bg-white active:text-blue-900',
+    link: 'px-0 bg-transparent text-blue-800 hover:underline hover:text-blue-900 active:text-blue-900 active:no-underline',
+  },
+  natural: {
+    solid: 'bg-navy-600 text-white hover:bg-navy-700',
+    border: 'bg-white text-navy-600 border border-navy-300 hover:bg-navy-100',
+    borderless: 'px-2 bg-transparent text-navy-600 hover:bg-navy-50 active:bg-navy-100',
+    link: 'px-0 bg-transparent text-navy-600 hover:underline hover:text-navy-700 active:no-underline',
+  },
+  warning: {
+    solid: 'bg-red-600 text-white hover:bg-red-700',
+    border: 'bg-white text-red-600 border border-red-600 hover:bg-navy-100 hover:text-red-700',
+    borderless:
+      'px-2 bg-transparent text-red-600 hover:bg-navy-50 hover:border-[1.5px] hover:border-red-700 hover:text-red-700',
+    link: 'px-0 bg-transparent text-red-600 hover:underline hover:text-red-700 active:no-underline',
+  },
+};
+
+const Button = ({
+  styleType = 'primary',
+  variant = 'solid',
+  disabled = false,
+  className,
+  children,
+  ...props
+}: Props) => {
+  const buttonClass = generateClassNames(
+    'h-11 px-5 items-center justify-center rounded-full transition duration-200',
+    {
+      [types[styleType][variant]]: !disabled,
+      'bg-navy-200 border-navy-200 text-navy-300 cursor-not-allowed': disabled,
+    },
+    className,
+  );
+
+  return (
+    <button className={buttonClass} disabled={disabled} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/frontend/src/components/common/Button/index.ts
+++ b/frontend/src/components/common/Button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button';
+export type { StyleTypes, Variants, Props } from './Button.interface';

--- a/frontend/src/components/common/LadderCard/LadderCard.tsx
+++ b/frontend/src/components/common/LadderCard/LadderCard.tsx
@@ -4,7 +4,7 @@ import { LadderCardInterface } from './LadderCard.interface';
 export const LadderCard = ({ ladderName, ladderSlug }: LadderCardInterface) => (
   <Link
     href={`/library/${ladderSlug}`}
-    className="border border-navy-200 bg-white rounded-2xl flex justify-center items-center h-44 cursor-pointer hover:bg-navy-100"
+    className="flex h-44 cursor-pointer items-center justify-center rounded-2xl border border-navy-200 bg-white hover:bg-navy-100"
   >
     <h2>{ladderName}</h2>
   </Link>

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -19,11 +19,11 @@ export const Modal = ({ children, open, onClose, title }: ModalProps) => (
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <div className="fixed w-full h-full inset-0 bg-navy-50/75 transition-opacity" />
+        <div className="fixed inset-0 h-full w-full bg-navy-50/75 transition-opacity" />
       </Transition.Child>
 
       <div className="fixed inset-0 z-10">
-        <div className="flex justify-center h-full text-center items-center">
+        <div className="flex h-full items-center justify-center text-center">
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -33,7 +33,7 @@ export const Modal = ({ children, open, onClose, title }: ModalProps) => (
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <Dialog.Panel className="relative h-full sm:max-h-[672px] text-left bg-white rounded-xl shadow-xl transition-all max-w-[80%] sm:max-w-2xl p-0 w-full">
+            <Dialog.Panel className="relative h-full w-full max-w-[80%] rounded-xl bg-white p-0 text-left shadow-xl transition-all sm:max-h-[672px] sm:max-w-2xl">
               <div className="flex justify-between p-8">
                 <Dialog.Title as="h3" className="text-xl font-medium text-navy-900">
                   {title}
@@ -43,7 +43,7 @@ export const Modal = ({ children, open, onClose, title }: ModalProps) => (
                 </button>
               </div>
 
-              <Dialog.Description className="overflow-y-auto py-5 px-8 h-[calc(100%-6rem)]">
+              <Dialog.Description className="h-[calc(100%-6rem)] overflow-y-auto px-8 py-5">
                 {children}
               </Dialog.Description>
             </Dialog.Panel>

--- a/frontend/src/components/modules/AdvancementLevel/AdvancementLevel.tsx
+++ b/frontend/src/components/modules/AdvancementLevel/AdvancementLevel.tsx
@@ -15,26 +15,26 @@ export const AdvancementLevel: React.FC<AdvancementLevelProps> = ({ showVertical
 
   return (
     <div className="flex flex-row">
-      <div className="flex flex-col items-center relative">
+      <div className="relative flex flex-col items-center">
         <div
-          className="mt-4 mb-2 bg-blue-800 rounded-full w-6 h-6 flex items-center justify-center hover:opacity-50"
+          className="mb-2 mt-4 flex h-6 w-6 items-center justify-center rounded-full bg-blue-800 hover:opacity-50"
           onClick={toggleAccordionOpen}
         >
-          <ChevronRightIcon className={`text-white w-3.5 h-3.5 ${!accordionOpen ? 'rotate-90' : '-rotate-90'}`} />
+          <ChevronRightIcon className={`h-3.5 w-3.5 text-white ${!accordionOpen ? 'rotate-90' : '-rotate-90'}`} />
         </div>
-        {showVerticalLine && <div className="w-[1.5px] bg-blue-800 absolute top-12 left-3 h-[calc(100%-40px)]" />}
+        {showVerticalLine && <div className="absolute left-3 top-12 h-[calc(100%-40px)] w-[1.5px] bg-blue-800" />}
       </div>
       <div
-        className={`p-4 ml-2 flex flex-col gap-4 mb-4 w-full rounded-lg ${!accordionOpen && 'hover:bg-navy-50'}`}
+        className={`mb-4 ml-2 flex w-full flex-col gap-4 rounded-lg p-4 ${!accordionOpen && 'hover:bg-navy-50'}`}
         onClick={accordionOpen ? undefined : toggleAccordionOpen}
       >
         <h3>Advancement level {advancementLevel}</h3>
-        <p className="text-base text-navy-600 tracking-wide">{description}</p>
+        <p className="text-base tracking-wide text-navy-600">{description}</p>
         {accordionOpen && (
           <>
             {projects.length > 0 && (
               <button
-                className="text-blue-800 text-sm hover:text-blue-900 hover:underline hover:underline-offset-4 font-semibold w-fit"
+                className="w-fit text-sm font-semibold text-blue-800 hover:text-blue-900 hover:underline hover:underline-offset-4"
                 onClick={openModal}
               >
                 An example way to pass level
@@ -61,9 +61,9 @@ export const AdvancementLevel: React.FC<AdvancementLevelProps> = ({ showVertical
       </div>
       <Modal open={modalOpen} onClose={hideModal} title="An example way to pass level">
         {projects.map(({ title, overview }) => (
-          <div key={title} className="text-navy-600 text-base overflow-hidden">
+          <div key={title} className="overflow-hidden text-base text-navy-600">
             <p>{title}</p>
-            <article className="mt-5 prose">
+            <article className="prose mt-5">
               <Markdown text={overview} />
             </article>
           </div>

--- a/frontend/src/components/modules/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/src/components/modules/Breadcrumbs/Breadcrumbs.tsx
@@ -11,7 +11,7 @@ export const Breadcrumbs = ({ breadcrumbs }: BreadcrumbsProps) => {
           <li key={breadcrumb.label}>
             <div className="flex items-center">
               {index !== 0 && (
-                <ChevronRightIcon className="h-4 w-4 flex-shrink-0 text-gray-400 mr-2" aria-hidden="true" />
+                <ChevronRightIcon className="text-gray-400 mr-2 h-4 w-4 flex-shrink-0" aria-hidden="true" />
               )}
               <Link
                 href={breadcrumb.href}

--- a/frontend/src/components/modules/BucketDetails/BucketDetails.tsx
+++ b/frontend/src/components/modules/BucketDetails/BucketDetails.tsx
@@ -6,11 +6,11 @@ export const BucketDetails: React.FC<BucketDetailsProps> = ({ data }) => {
 
   return (
     <section className="py-16">
-      <div className="rounded-2xl mx-28 bg-white px-20 py-12 flex flex-col gap-8">
+      <div className="mx-28 flex flex-col gap-8 rounded-2xl bg-white px-20 py-12">
         <div className="flex justify-between">
           <div className="flex flex-col gap-3">
             <h2 className="text-xl font-semibold text-navy-900">{bucketName}</h2>
-            <p className="text-base text-navy-600 tracking-wide">{description}</p>
+            <p className="text-base tracking-wide text-navy-600">{description}</p>
           </div>
         </div>
         <div className="flex flex-col">

--- a/frontend/src/components/modules/LadderDetails/LadderDetails.tsx
+++ b/frontend/src/components/modules/LadderDetails/LadderDetails.tsx
@@ -8,16 +8,16 @@ import { AccordionList } from '@app/components/common/AccordionList';
 
 export const LadderDetails = ({ ladder, ladderName, band }: LadderDetailsProps) => {
   return (
-    <div className="rounded-2xl bg-white px-20 py-12 flex flex-col gap-8">
+    <div className="flex flex-col gap-8 rounded-2xl bg-white px-20 py-12">
       <div className="flex justify-between">
         <div className="flex flex-col gap-3">
           <h2 className="text-xl font-semibold text-navy-900">
             Band {band}: {ladderName}
           </h2>
-          <p className="text-navy-600 text-l font-medium">Salary range: {ladder.salaryRange}</p>
+          <p className="text-l font-medium text-navy-600">Salary range: {ladder.salaryRange}</p>
         </div>
-        <div className="rounded-xl border border-navy-200 p-4 flex flex-col items-center">
-          <div className="flex gap-2 justify-between text-navy-600">
+        <div className="flex flex-col items-center rounded-xl border border-navy-200 p-4">
+          <div className="flex justify-between gap-2 text-navy-600">
             <p>Threshold</p>
             <InfoIcon
               className="text-navy-600"
@@ -31,9 +31,9 @@ export const LadderDetails = ({ ladder, ladderName, band }: LadderDetailsProps) 
         </div>
       </div>
       <div className="flex flex-col gap-6">
-        <p className="text-base text-navy-600 tracking-wide">Buckets you need to complete to get on this band:</p>
+        <p className="text-base tracking-wide text-navy-600">Buckets you need to complete to get on this band:</p>
         <div className="flex flex-col gap-4">
-          <p className="text-sm text-navy-600 uppercase tracking-wide">Hard skills</p>
+          <p className="text-sm uppercase tracking-wide text-navy-600">Hard skills</p>
           <div className="flex flex-col gap-6">
             {ladder.hardSkillBuckets.map((bucket: LadderBandBucket) => (
               <BucketCard bucket={bucket} key={bucket.bucketSlug} />
@@ -41,7 +41,7 @@ export const LadderDetails = ({ ladder, ladderName, band }: LadderDetailsProps) 
           </div>
         </div>
         <div className="flex flex-col gap-4">
-          <p className="text-sm text-navy-600 uppercase tracking-wide">Soft skills</p>
+          <p className="text-sm uppercase tracking-wide text-navy-600">Soft skills</p>
           <div className="flex flex-col gap-6">
             <AccordionCard title="Time management">
               <div className="flex flex-col gap-6">

--- a/frontend/src/components/modules/LadderTabs/LadderTabs.tsx
+++ b/frontend/src/components/modules/LadderTabs/LadderTabs.tsx
@@ -3,6 +3,7 @@ import { VerticalLineIcon } from '@app/static/icons/VerticalLineIcon';
 import { generateBandGrouping } from './utils';
 import { LadderTabsProps, LadderInterface } from './LadderTabs.interface';
 import { generateClassNames } from '@app/utils';
+import Button from '@app/components/common/Button/Button';
 
 export const LadderTabs: React.FC<LadderTabsProps> = ({ maximumLadders, activeLadder, ladderOnClick }) => {
   const generateLadders = useCallback((maxLadders: number): LadderInterface => generateBandGrouping(maxLadders), []);
@@ -10,22 +11,23 @@ export const LadderTabs: React.FC<LadderTabsProps> = ({ maximumLadders, activeLa
   const ladders: LadderInterface = useMemo(() => generateLadders(maximumLadders), [generateLadders, maximumLadders]);
 
   return (
-    <div className="w-[88px] flex flex-col">
+    <div className="flex w-[88px] flex-col">
       {Object.keys(ladders).map((positionName: string, index: number) => (
         <Fragment key={positionName}>
-          <div className="rounded-2xl px-2 py-3 bg-white">
-            <h3 className="text-center uppercase text-xs text-navy-600 tracking-wide mb-2">{positionName}</h3>
+          <div className="rounded-2xl bg-white px-2 py-3">
+            <h3 className="mb-2 text-center text-xs uppercase tracking-wide text-navy-600">{positionName}</h3>
             {ladders[positionName].map((ladder: number, index: number) => (
               <Fragment key={ladder.toString()}>
-                <div
+                <Button
                   onClick={() => ladderOnClick && ladderOnClick(ladder)}
-                  className={generateClassNames(
-                    'border-2 border-navy-300 text-navy-600 p-2 py-[6px] rounded-full flex items-center justify-center hover:border-blue-800 hover:text-white hover:bg-blue-800 cursor-pointer transition-colors duration-300 ease-in-out',
-                    { 'bg-blue-800 text-white border-blue-800': ladder === activeLadder },
-                  )}
+                  className={generateClassNames('w-full', {
+                    'pointer-events-none border-blue-800 bg-blue-800 text-white': ladder === activeLadder,
+                  })}
+                  styleType="natural"
+                  variant="border"
                 >
                   {ladder}
-                </div>
+                </Button>
                 {index !== ladders[positionName].length - 1 && (
                   <VerticalLineIcon className="h-6 w-full text-navy-300" />
                 )}
@@ -33,7 +35,7 @@ export const LadderTabs: React.FC<LadderTabsProps> = ({ maximumLadders, activeLa
             ))}
           </div>
           {index !== Object.keys(ladders).length - 1 && (
-            <VerticalLineIcon className="h-6 w-full text-navy-300 text-center" />
+            <VerticalLineIcon className="h-6 w-full text-center text-navy-300" />
           )}
         </Fragment>
       ))}

--- a/frontend/src/components/modules/LadderTabs/LadderTabs.tsx
+++ b/frontend/src/components/modules/LadderTabs/LadderTabs.tsx
@@ -3,7 +3,7 @@ import { VerticalLineIcon } from '@app/static/icons/VerticalLineIcon';
 import { generateBandGrouping } from './utils';
 import { LadderTabsProps, LadderInterface } from './LadderTabs.interface';
 import { generateClassNames } from '@app/utils';
-import Button from '@app/components/common/Button/Button';
+import { Button } from '@app/components/common/Button';
 
 export const LadderTabs: React.FC<LadderTabsProps> = ({ maximumLadders, activeLadder, ladderOnClick }) => {
   const generateLadders = useCallback((maxLadders: number): LadderInterface => generateBandGrouping(maxLadders), []);
@@ -15,7 +15,7 @@ export const LadderTabs: React.FC<LadderTabsProps> = ({ maximumLadders, activeLa
       {Object.keys(ladders).map((positionName: string, index: number) => (
         <Fragment key={positionName}>
           <div className="rounded-2xl bg-white px-2 py-3">
-            <h3 className="mb-2 text-center text-xs uppercase tracking-wide text-navy-600">{positionName}</h3>
+            <h3 className="text-xs mb-2 text-center uppercase tracking-wide text-navy-600">{positionName}</h3>
             {ladders[positionName].map((ladder: number, index: number) => (
               <Fragment key={ladder.toString()}>
                 <Button

--- a/frontend/src/components/modules/LibraryDetailed/LibraryDetailed.tsx
+++ b/frontend/src/components/modules/LibraryDetailed/LibraryDetailed.tsx
@@ -36,7 +36,7 @@ export const LibraryDetailed: React.FC<LibraryDetailedProps> = ({ data }) => {
   }
 
   return (
-    <section className="py-16 grid grid-cols-10">
+    <section className="grid grid-cols-10 py-16">
       <div className="col-span-2 mx-auto">
         <LadderTabs {...tabsProps} ladderOnClick={handleLadderChange} />
       </div>

--- a/frontend/src/components/modules/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/modules/Sidebar/Sidebar.tsx
@@ -16,7 +16,7 @@ export const Sidebar = () => {
 
   return (
     <nav
-      className={`z-50 h-screen ${open ? 'w-72' : 'w-16'} ${duration} flex flex-col bg-white px-3 border-r border-navy-200`}
+      className={`z-50 h-screen ${open ? 'w-72' : 'w-16'} ${duration} flex flex-col border-r border-navy-200 bg-white px-3`}
     >
       <div className="flex h-16 shrink-0 justify-between">
         <div className={`${duration} flex ${open ? 'opacity-1' : 'opacity-0'}`}>
@@ -28,7 +28,7 @@ export const Sidebar = () => {
           />
         </div>
         <Button onClick={toggleSidebar}>
-          <ChevronDoubleLeft className={`flex ${duration} ${open ? '' : 'rotate-180 mr-2'}`} />
+          <ChevronDoubleLeft className={`flex ${duration} ${open ? '' : 'mr-2 rotate-180'}`} />
         </Button>
       </div>
       <ul role="list" className="flex flex-1 flex-col gap-y-7">
@@ -39,12 +39,12 @@ export const Sidebar = () => {
                 <Link
                   href={item.href}
                   className={generateClassNames(
-                    'flex items-center p-2 rounded-md font-medium text-navy-600 hover:bg-blue-100 whitespace-nowrap',
+                    'flex items-center whitespace-nowrap rounded-md p-2 font-medium text-navy-600 hover:bg-blue-100',
                     { 'bg-blue-100 text-blue-900': item.current },
                   )}
                 >
-                  <div className="flex gap-x-3 items-center">
-                    <item.icon className="w-5 h-5" />
+                  <div className="flex items-center gap-x-3">
+                    <item.icon className="h-5 w-5" />
                     <span className={`${duration} leading-6 ${open ? 'text-sm' : 'text-[0px]'}`}>{item.name}</span>
                   </div>
                 </Link>

--- a/frontend/src/components/modules/Topbar/Topbar.tsx
+++ b/frontend/src/components/modules/Topbar/Topbar.tsx
@@ -6,11 +6,11 @@ import { NotificationIcon } from '@app/static/icons/NotificationIcon';
 
 export const Topbar = () => {
   return (
-    <div className="bg-white mx-auto p-4 border-b border-navy-200 sticky top-0 z-40 shrink-0">
-      <div className="flex justify-end items-center px-2">
+    <div className="sticky top-0 z-40 mx-auto shrink-0 border-b border-navy-200 bg-white p-4">
+      <div className="flex items-center justify-end px-2">
         <button
           type="button"
-          className="relative rounded-full bg-gray-800 p-1 text-gray-400 focus:outline-none focus:ring-2"
+          className="bg-gray-800 text-gray-400 relative rounded-full p-1 focus:outline-none focus:ring-2"
         >
           <span className="absolute -inset-1.5" />
           <span className="sr-only">View notifications</span>
@@ -20,7 +20,7 @@ export const Topbar = () => {
         {/* Profile dropdown */}
         <Menu as="div" className="relative ml-3">
           <div>
-            <Menu.Button className="relative flex rounded-full bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
+            <Menu.Button className="bg-gray-800 focus:ring-offset-gray-800 relative flex rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2">
               <span className="absolute -inset-1.5" />
               <span className="sr-only">Open user menu</span>
               <Image
@@ -40,10 +40,10 @@ export const Topbar = () => {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Menu.Items className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+            <Menu.Items className="ring-black absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-opacity-5 focus:outline-none">
               <Menu.Item>
                 {() => (
-                  <a href="#" className="block px-4 py-2 text-sm text-gray-700">
+                  <a href="#" className="text-gray-700 block px-4 py-2 text-sm">
                     Sign out
                   </a>
                 )}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -52,12 +52,12 @@ const config: Config = {
       },
     },
     fontSize: {
-      sm: ['0.875rem', '1.225rem'],   // Body S
-      base: ['1rem', '1.5rem'],       // Body M
-      xl: ['1.25rem', '1.75rem'],     // Headline S
-      '2xl': ['1.5rem', '1.875rem'],  // Headline M
-      '3xl': ['2rem', '2.5rem'],      // Headline L
-      '4xl': ['2.5rem', '3.125rem'],  // Headline XL
+      sm: ['0.875rem', '1.225rem'], // Body S
+      base: ['1rem', '1.5rem'], // Body M
+      xl: ['1.25rem', '1.75rem'], // Headline S
+      '2xl': ['1.5rem', '1.875rem'], // Headline M
+      '3xl': ['2rem', '2.5rem'], // Headline L
+      '4xl': ['2.5rem', '3.125rem'], // Headline XL
       '5xl': ['3.75rem', '4.375rem'], // Headline 2XL
     },
     extend: {
@@ -66,12 +66,10 @@ const config: Config = {
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
       fontSize: {
-        l: ['1.125rem', '1.625rem'],    // Body L
-      }
+        l: ['1.125rem', '1.625rem'], // Body L
+      },
     },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
+  plugins: [require('@tailwindcss/typography')],
 };
 export default config;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -326,6 +326,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@swc/helpers@^0.5.0":
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.11.tgz#5bab8c660a6e23c13b2d23fcd1ee44a2db1b0cb7"
+  integrity sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==
+  dependencies:
+    tslib "^2.4.0"
+
 "@tailwindcss/typography@^0.5.13":
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.13.tgz#cd788a4fa4d0ca2506e242d512f377b22c1f7932"
@@ -335,13 +342,6 @@
     lodash.isplainobject "^4.0.6"
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
-
-"@tanstack/react-virtual@^3.0.0-beta.60":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.2.0.tgz#fb70f9c6baee753a5a0f7618ac886205d5a02af9"
-  integrity sha512-OEdMByf2hEfDa6XDbGlZN8qO6bTjlNKqjM3im9JG+u3mCL8jALy0T/67oDI001raUUPh1Bdmfn4ZvPOV5knpcg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@tanstack/react-virtual@3.5.0":
   version "3.5.0"
@@ -3025,6 +3025,11 @@ prettier-linter-helpers@^1.0.0:
   integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
   dependencies:
     fast-diff "^1.1.2"
+
+prettier-plugin-tailwindcss@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz#e05202784a3f41889711ae38c75c5b8cad72f368"
+  integrity sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==
 
 prettier@3.2.5:
   version "3.2.5"


### PR DESCRIPTION
I've added `children` prop as content for the button component instead of something like `title` so we can pass icons there instead of setting something like `rightContent`, `leftContent`. But if you think its better to have it specified by props I'm also down for changing it
#42 